### PR TITLE
fix permissions in the ci job and use best practices for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/build-backend-container.yaml
+++ b/.github/workflows/build-backend-container.yaml
@@ -16,29 +16,28 @@ jobs:
       id-token: write
 
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        uses: sigstore/cosign-installer@v3.5.0
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           username: ${{ secrets.DH_USERNAME }}
           password: ${{ secrets.DH_PASSWORD }}
-      -
-        name: Build and push API
+
+      - name: Build and push API
         id: build-and-push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: ./
           push: true
           tags: nullchannel/twitch-alerts:${{ github.sha }}
+
       - name: Sign the images with GitHub OIDC Token
         run: |
           cosign sign --yes "nullchannel/twitch-alerts:${{ github.sha }}@${{ steps.build-and-push.outputs.digest }}"
-

--- a/.github/workflows/build-backend-container.yaml
+++ b/.github/workflows/build-backend-container.yaml
@@ -6,14 +6,15 @@ on:
       - 'main'
   workflow_dispatch:
 
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
       id-token: write
 
-jobs:
-  docker:
-    runs-on: ubuntu-latest
     steps:
       -
         name: Checkout

--- a/.github/workflows/build-ui-container.yaml
+++ b/.github/workflows/build-ui-container.yaml
@@ -10,41 +10,40 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - 
-        name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
             toolchain: stable
             default: true
             target: wasm32-unknown-unknown
             override: true
             components: rustfmt, clippy
-      -
-        name: Install Trunk
+
+      - name: Install Trunk
         run: cargo install trunk
-      -
-        name: Build UI
+
+      - name: Build UI
         run: |
           cd frontend/wasm
           trunk build --release
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           username: ${{ secrets.DH_USERNAME }}
           password: ${{ secrets.DH_PASSWORD }}
-      -
-        name: Build and push API
-        uses: docker/build-push-action@v4
+
+      - name: Build and push API
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         with:
           context: ./frontend/wasm/
           push: true


### PR DESCRIPTION
- fix permission syntax
- use best practice and pin the actions to a git hash instead of tags and udpates to latest release available
- add dependabot config to update the github actions



cc @amouat